### PR TITLE
[CLOUD-988] Bump up retool version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "postgresql_db_port" {
 variable "retool_release_version" {
   description = "Official Retool release version found: https://github.com/tryretool/retool-onpremise#select-a-retool-version-number"
   type        = string
-  default     = "2.106.3"
+  default     = "3.16.9"
 }
 
 variable "retool_alb_sg_ingress_cidr_blocks" {


### PR DESCRIPTION
[CLOUD-988](https://actioniq.atlassian.net/browse/CLOUD-988)

This PR bumps up the `retool` version on a AIQ self-hosted instance.

[CLOUD-988]: https://actioniq.atlassian.net/browse/CLOUD-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ