### PR TITLE
[CLOUD-988] bump retool version to 2.116.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "postgresql_db_port" {
 variable "retool_release_version" {
   description = "Official Retool release version found: https://github.com/tryretool/retool-onpremise#select-a-retool-version-number"
   type        = string
-  default     = "2.116"
+  default     = "2.116.2"
 }
 
 variable "retool_alb_sg_ingress_cidr_blocks" {


### PR DESCRIPTION
Following the Retool support eng recommended upgrade path bumping up the version to 2.116:

`2.106.3 -> 2.116 -> test -> 2.123 -> test extensively -> 3.0 -> triple check to make sure everything works -> 3.10 -> 3.16/latest`