### PR TITLE
[CLOUD-1064] Upgrading RDS engine version to 12.16

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -215,7 +215,7 @@ variable "retool_rds_cluster_engine" {
 variable "retool_rds_cluster_engine_version" {
   description = "AWS RDS Cluster engine version - this is despendent on var.retool_rds_cluster_engine"
   type        = number
-  default     = "11.17"
+  default     = "12.16"
 }
 
 variable "retool_rds_cluster_instance_count" {


### PR DESCRIPTION
[CLOUD-1064](https://actioniq.atlassian.net/browse/CLOUD-1064)

This PR catches up the code with a `retool` RDS engine upgrade from 11.17 to 12.16. The change results in net zero diff: RDS cluster was upgraded using blue/green deployment.
The upgrade is needed to avoid extended maintenance fees that AWS will start charging by the end of the Feb, 2024.

[CLOUD-1064]: https://actioniq.atlassian.net/browse/CLOUD-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ